### PR TITLE
feat: Add admin mode with teacher authentication (Fixes #5)

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,13 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="header-top">
+        <div>
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+        <button id="user-icon" class="user-icon" title="Click to login">👤</button>
+      </div>
     </header>
 
     <main>
@@ -40,6 +45,38 @@
         <div id="message" class="hidden"></div>
       </section>
     </main>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Teacher Login</h2>
+          <button class="close-btn" id="close-login">&times;</button>
+        </div>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="Enter your username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="Enter your password" />
+          </div>
+          <button type="submit" class="login-btn">Login</button>
+        </form>
+        <div id="login-message" class="hidden"></div>
+      </div>
+    </div>
+
+    <!-- Admin Panel -->
+    <div id="admin-panel" class="admin-panel hidden">
+      <div class="admin-header">
+        <h3>Admin Mode</h3>
+        <div class="admin-user">Logged in as: <span id="current-user">N/A</span></div>
+        <button id="logout-btn" class="logout-btn">Logout</button>
+      </div>
+      <p class="admin-info">You now have admin access. You can register and unregister students using the form above.</p>
+    </div>
 
     <footer>
       <p>&copy; 2023 Mergington High School</p>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -24,8 +24,39 @@ header {
   border-radius: 5px;
 }
 
+.header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 20px;
+}
+
+.header-top > div {
+  flex: 1;
+}
+
 header h1 {
   margin-bottom: 10px;
+}
+
+.user-icon {
+  font-size: 28px;
+  background-color: transparent;
+  border: 2px solid white;
+  border-radius: 50%;
+  width: 45px;
+  height: 45px;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s;
+}
+
+.user-icon:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  transform: scale(1.1);
 }
 
 main {
@@ -197,4 +228,121 @@ footer {
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+/* Modal Styles */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 30px;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  max-width: 400px;
+  width: 90%;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 10px;
+}
+
+.modal-header h2 {
+  margin: 0;
+  color: #1a237e;
+}
+
+.close-btn {
+  background-color: transparent;
+  color: #999;
+  font-size: 24px;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  width: 30px;
+  height: 30px;
+}
+
+.close-btn:hover {
+  color: #1a237e;
+  background-color: #f5f5f5;
+}
+
+.login-btn {
+  width: 100%;
+  margin-top: 15px;
+}
+
+#login-message {
+  margin-top: 15px;
+  padding: 10px;
+  border-radius: 4px;
+}
+
+/* Admin Panel Styles */
+.admin-panel {
+  background-color: #e3f2fd;
+  border: 2px solid #1a237e;
+  padding: 15px 20px;
+  margin-bottom: 20px;
+  border-radius: 5px;
+  width: 100%;
+}
+
+.admin-panel.hidden {
+  display: none;
+}
+
+.admin-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.admin-header h3 {
+  margin: 0;
+  color: #1a237e;
+}
+
+.admin-user {
+  font-weight: bold;
+  color: #1a237e;
+}
+
+.logout-btn {
+  background-color: #d32f2f;
+  padding: 8px 12px;
+  font-size: 14px;
+}
+
+.logout-btn:hover {
+  background-color: #b71c1c;
+}
+
+.admin-info {
+  margin: 0;
+  color: #1565c0;
+  font-style: italic;
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,16 @@
+{
+  "teachers": [
+    {
+      "username": "msmith",
+      "password": "TeachSecure123!"
+    },
+    {
+      "username": "jchen",
+      "password": "Education456!"
+    },
+    {
+      "username": "lbrown",
+      "password": "Mentoring789!"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Resolves #5: Admin Mode

This pull request implements teacher authentication and admin controls to prevent students from removing each other from activities.

## Changes
- **Backend**: Added `/login` endpoint with teacher credential validation from `teachers.json`
- **Frontend**: 
  - Added login modal accessible via user icon in header
  - Admin panel displays when teacher is logged in
  - Delete buttons (❌) only visible to authenticated teachers
  - Students cannot unregister others without authentication
- **UI/UX**:
  - User icon changes from 👤 (student) to 👨‍🏫 (teacher) when logged in
  - Responsive modal design for login form
  - Admin panel shows current logged-in username with logout option

## Teacher Credentials
Sample credentials included in `teachers.json`:
- `msmith` / `TeachSecure123!`
- `jchen` / `Education456!`
- `lbrown` / `Mentoring789!`

## Testing
1. Load the page as a regular student
2. Try clicking the delete button - should show an error message
3. Click the user icon (👤) to open login modal
4. Login with any of the teacher credentials above
5. Notice user icon changes to 👨‍🏫 and delete buttons become available
6. Click the logout button to exit admin mode

## Resolves
Fixes #5 - Prevents students from removing each other to free up spaces in activities